### PR TITLE
fix: hydrate lobby state on client join

### DIFF
--- a/packages/client/src/scenes/Background.ts
+++ b/packages/client/src/scenes/Background.ts
@@ -6,14 +6,11 @@ export class Background extends Scene {
   }
 
   create() {
-    this.cameras.main.setBackgroundColor(0xffffff);
+    this.cameras.main.setBackgroundColor(0x70c5ce);
     this.scene.sendToBack();
 
-    const fridge_bg = this.add.image(
-      Number(this.game.config.width) / 2,
-      Number(this.game.config.height) / 2,
-      "fridge_bg"
-    );
-    fridge_bg.setScale(0.4);
+    const { width, height } = this.cameras.main;
+    this.add.tileSprite(0, 0, width * 1.5, height, "background-day").setOrigin(0, 0);
+    this.add.tileSprite(0, height - 112, width * 1.5, 112, "base").setOrigin(0, 0);
   }
 }

--- a/packages/client/src/scenes/Boot.ts
+++ b/packages/client/src/scenes/Boot.ts
@@ -9,9 +9,9 @@ export class Boot extends Scene {
     //  The Boot Scene is typically used to load in any assets you require for your Preloader, such as a game logo or background.
     //  The smaller the file size of the assets, the better, as the Boot Scene itself has no preloader.
 
-    this.load.setPath("/.proxy/assets");
-    this.load.image("background", "bg.png");
-    this.load.image("fridge_bg", "fridge_bg.png");
+    this.load.setPath("/.proxy/assets/flappy-bird-assets/sprites");
+    this.load.image("background-day", "background-day.png");
+    this.load.image("base", "base.png");
   }
 
   create() {

--- a/packages/client/src/scenes/Game.ts
+++ b/packages/client/src/scenes/Game.ts
@@ -2,88 +2,540 @@ import { Scene } from "phaser";
 import { Room, Client, getStateCallbacks } from "colyseus.js";
 import { getUserName } from "../utils/discordSDK";
 
+type PlayerState = {
+  name: string;
+  skin: "yellow" | "blue" | "red";
+  ready: boolean;
+  y: number;
+  velocity: number;
+  alive: boolean;
+  score: number;
+  lastPassedPipeId: number;
+};
+
+type PipeState = {
+  id: number;
+  x: number;
+  gapY: number;
+};
+
 export class Game extends Scene {
-  room: Room;
+  private room?: Room<any>;
+  private background!: Phaser.GameObjects.TileSprite;
+  private ground!: Phaser.GameObjects.TileSprite;
+  private playerSprites = new Map<string, Phaser.GameObjects.Sprite>();
+  private pipeSprites = new Map<number, { top: Phaser.GameObjects.Image; bottom: Phaser.GameObjects.Image }>();
+  private playerCache = new Map<string, { alive: boolean; score: number }>();
+  private scoreText!: Phaser.GameObjects.Text;
+  private scoreBackdrop!: Phaser.GameObjects.Rectangle;
+  private statusText!: Phaser.GameObjects.Text;
+  private readyButton!: Phaser.GameObjects.Container;
+  private readyButtonBg!: Phaser.GameObjects.Rectangle;
+  private readyButtonText!: Phaser.GameObjects.Text;
+  private readyInfoText!: Phaser.GameObjects.Text;
+  private localPlayerId = "";
+  private localReady = false;
+  private readonly pipeGap = 230;
+  private readonly birdX = 260;
+  private readonly scrollSpeed = 220;
 
   constructor() {
     super("Game");
   }
 
   async create() {
-    this.scene.launch("background");
-
-    const grid = this.add.image(this.cameras.main.width * 0.5, this.cameras.main.height * 0.4, "grid");
-    grid.setScale(0.6);
+    this.setupWorld();
+    this.setupUI();
+    this.setupInput();
 
     await this.connect();
-
-    const $ = getStateCallbacks(this.room);
-
-    $(this.room.state).draggables.onAdd((draggable: any, draggableId: string) => {
-      const image = this.add.image(draggable.x, draggable.y, draggableId).setInteractive();
-      image.name = draggableId;
-      image.setScale(0.8);
-
-      this.input.setDraggable(image);
-      image.on("drag", (pointer, dragX, dragY) => {
-        if (!this.room) {
-          return;
-        }
-
-        // Clamp drag position to screen bounds
-        image.x = Phaser.Math.Clamp(
-          dragX,
-          image.displayWidth / 2,
-          Number(this.game.config.width) - image.displayWidth / 2
-        );
-        image.y = Phaser.Math.Clamp(
-          dragY,
-          image.displayHeight / 2,
-          Number(this.game.config.height) - image.displayHeight / 2
-        );
-
-        // Send position update to the server
-        this.room.send("move", {
-          imageId: draggableId,
-          x: image.x,
-          y: image.y,
-        });
-      });
-
-      $(draggable).onChange(() => {
-        image.x = draggable.x;
-        image.y = draggable.y;
-      });
-    });
-
-    this.add
-      .text(this.cameras.main.width * 0.5, this.cameras.main.height * 0.95, `Connected as: ${getUserName()}`, {
-        font: "14px Arial",
-        color: "#000000",
-      })
-      .setOrigin(0.5);
+    this.registerStateListeners();
   }
 
-  async connect() {
+  update(_time: number, delta: number) {
+    const scroll = (this.scrollSpeed * delta) / 1000;
+    this.background.tilePositionX += scroll;
+    this.ground.tilePositionX += scroll;
+  }
+
+  private setupWorld() {
+    const { width, height } = this.cameras.main;
+
+    this.background = this.add.tileSprite(0, 0, width * 1.5, height, "background-day").setOrigin(0, 0);
+    this.ground = this.add.tileSprite(0, height - 112, width * 1.5, 112, "base").setOrigin(0, 0);
+  }
+
+  private setupUI() {
+    const width = Number(this.game.config.width);
+
+    this.scoreBackdrop = this.add
+      .rectangle(width / 2, 40, width * 0.6, 70, 0x000000, 0.35)
+      .setOrigin(0.5)
+      .setDepth(10);
+
+    this.scoreText = this.add
+      .text(width / 2, 40, "Connecting...", {
+        fontFamily: "Arial Black",
+        fontSize: 30,
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 8,
+        align: "center",
+      })
+      .setOrigin(0.5)
+      .setDepth(11);
+
+    this.statusText = this.add
+      .text(width / 2, 120, "Waiting for players...", {
+        fontFamily: "Arial",
+        fontSize: 26,
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 6,
+        align: "center",
+      })
+      .setOrigin(0.5)
+      .setDepth(11);
+
+    this.readyButton = this.add
+      .container(width / 2, Number(this.game.config.height) - 140)
+      .setDepth(11);
+    this.readyButton.setSize(280, 68);
+    this.readyButton.setInteractive({ useHandCursor: true });
+    this.readyButton.on("pointerdown", () => this.handleReadyButton());
+
+    this.readyButtonBg = this.add.rectangle(0, 0, 280, 68, 0xe67e22, 0.9);
+    this.readyButtonBg.setStrokeStyle(3, 0xffffff, 0.9);
+    this.readyButtonBg.setOrigin(0.5);
+
+    this.readyButtonText = this.add
+      .text(0, 0, "Ready Up", {
+        fontFamily: "Arial Black",
+        fontSize: 26,
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 6,
+        align: "center",
+      })
+      .setOrigin(0.5);
+
+    this.readyButton.add([this.readyButtonBg, this.readyButtonText]);
+
+    this.readyInfoText = this.add
+      .text(width / 2, Number(this.game.config.height) - 80, "Ready: 0/0", {
+        fontFamily: "Arial",
+        fontSize: 22,
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 4,
+        align: "center",
+      })
+      .setOrigin(0.5)
+      .setDepth(11);
+
+    this.updateReadyUI();
+
+    this.add
+      .text(width / 2, Number(this.game.config.height) - 30, `Connected as: ${getUserName()}`, {
+        font: "18px Arial",
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 4,
+      })
+      .setOrigin(0.5)
+      .setDepth(11);
+  }
+
+  private setupInput() {
+    this.input.on("pointerdown", () => this.handleFlap());
+    this.input.keyboard?.on("keydown-SPACE", () => this.handleFlap());
+    this.input.keyboard?.on("keydown-UP", () => this.handleFlap());
+  }
+
+  private handleFlap() {
+    if (!this.room || !this.room.state.running) {
+      return;
+    }
+
+    this.room.send("flap");
+    this.sound.play("wing", { volume: 0.4 });
+  }
+
+  private handleReadyButton() {
+    if (!this.room || this.room.state.running) {
+      return;
+    }
+
+    const nextReady = !this.localReady;
+    this.localReady = nextReady;
+    this.updateReadyUI();
+    this.room.send("setReady", { ready: nextReady });
+  }
+
+  private async connect() {
     const url =
-      location.host === "localhost:3000" ? `ws://localhost:3001` : `wss://${location.host}/.proxy/api/colyseus`;
+      location.host === "localhost:3000"
+        ? `ws://localhost:3001`
+        : `wss://${location.host}/.proxy/api/colyseus`;
 
     const client = new Client(`${url}`);
 
     try {
       this.room = await client.joinOrCreate("game", {
-        // Let's send our client screen dimensions to the server for initial positioning
-        screenWidth: this.game.config.width,
-        screenHeight: this.game.config.height,
+        name: getUserName(),
       });
-
-      this.room.onMessage("move", (message) => {
-        //console.log("Move message received:", message);
-      });
-
-      console.log("Successfully connected!");
+      this.localPlayerId = this.room.sessionId;
+      this.updateReadyUI();
     } catch (e) {
       console.log(`Could not connect with the server: ${e}`);
+      this.scoreText.setText("Connection failed");
     }
+  }
+
+  private registerStateListeners() {
+    if (!this.room) {
+      return;
+    }
+
+    const $ = getStateCallbacks(this.room);
+
+    const bindPlayer = (player: PlayerState, sessionId: string) => {
+      if (this.playerSprites.has(sessionId)) {
+        return;
+      }
+
+      this.addPlayer(sessionId, player);
+      $(player).onChange((changes: any) => {
+        this.syncPlayer(sessionId, player, changes);
+      });
+    };
+
+    $(this.room.state.players).onAdd((player: PlayerState, sessionId: string) => {
+      bindPlayer(player, sessionId);
+    });
+
+    $(this.room.state.players).onRemove((_player: PlayerState, sessionId: string) => {
+      this.removePlayer(sessionId);
+    });
+
+    const bindPipe = (pipe: PipeState) => {
+      if (this.pipeSprites.has(pipe.id)) {
+        return;
+      }
+
+      this.addPipe(pipe);
+      $(pipe).onChange(() => {
+        this.updatePipe(pipe);
+      });
+    };
+
+    $(this.room.state.pipes).onAdd((pipe: PipeState) => {
+      bindPipe(pipe);
+    });
+
+    $(this.room.state.pipes).onRemove((pipe: PipeState) => {
+      this.removePipe(pipe.id);
+    });
+
+    $(this.room.state).onChange((changes: any[]) => {
+      changes.forEach((change) => {
+        if (change.field === "running" || change.field === "winnerId") {
+          this.updateStatusMessage();
+        }
+        if (change.field === "running") {
+          this.updateReadyUI();
+        }
+      });
+    });
+
+    this.room.state.players.forEach((player: PlayerState, sessionId: string) => {
+      bindPlayer(player, sessionId);
+    });
+
+    this.room.state.pipes.forEach((pipe: PipeState) => {
+      bindPipe(pipe);
+    });
+
+    this.updateStatusMessage();
+    this.updateReadyUI();
+    this.refreshReadyInfo();
+  }
+
+  private addPlayer(sessionId: string, player: PlayerState) {
+    const sprite = this.add.sprite(this.birdX, player.y, this.getBirdTexture(player.skin));
+    sprite.setDepth(5);
+    sprite.play(this.getBirdAnimation(player.skin));
+
+    if (sessionId === this.localPlayerId) {
+      sprite.setScale(1.05);
+      sprite.setTint(0xffffaa);
+    }
+
+    this.playerSprites.set(sessionId, sprite);
+    this.playerCache.set(sessionId, { alive: player.alive, score: player.score });
+    this.syncPlayer(sessionId, player, []);
+    this.refreshScoreboard();
+    this.updateStatusMessage();
+    this.updateReadyUI();
+    this.refreshReadyInfo();
+  }
+
+  private removePlayer(sessionId: string) {
+    const sprite = this.playerSprites.get(sessionId);
+    if (sprite) {
+      sprite.destroy();
+    }
+    this.playerSprites.delete(sessionId);
+    this.playerCache.delete(sessionId);
+    this.refreshScoreboard();
+    this.updateStatusMessage();
+    this.updateReadyUI();
+    this.refreshReadyInfo();
+  }
+
+  private syncPlayer(sessionId: string, player: PlayerState, changes: any[]) {
+    const sprite = this.playerSprites.get(sessionId);
+    if (!sprite) {
+      return;
+    }
+
+    sprite.y = player.y;
+    const rotation = Phaser.Math.Clamp(player.velocity / 600, -0.6, 1.0);
+    sprite.setRotation(rotation);
+
+    const cached = this.playerCache.get(sessionId);
+    if (cached) {
+      if (cached.alive && !player.alive && sessionId === this.localPlayerId) {
+        this.sound.play("hit", { volume: 0.4 });
+        this.sound.play("die", { volume: 0.4, delay: 0.1 });
+      }
+      if (player.score > cached.score && sessionId === this.localPlayerId) {
+        this.sound.play("point", { volume: 0.5 });
+      }
+    }
+
+    if (player.alive) {
+      sprite.clearTint();
+      if (sessionId === this.localPlayerId) {
+        sprite.setTint(0xffffaa);
+      }
+      sprite.setAlpha(1);
+    } else {
+      sprite.setTint(0x555555);
+      sprite.setAlpha(0.8);
+    }
+
+    this.playerCache.set(sessionId, { alive: player.alive, score: player.score });
+
+    if (sessionId === this.localPlayerId) {
+      this.localReady = player.ready;
+      this.updateReadyUI();
+    }
+
+    const changeList = Array.isArray(changes) ? changes : [];
+    const shouldRefresh = changeList.some(
+      (change: any) => change.field === "score" || change.field === "alive" || change.field === "ready",
+    );
+    if (shouldRefresh) {
+      this.refreshScoreboard();
+      this.updateStatusMessage();
+      this.refreshReadyInfo();
+    }
+  }
+
+  private getBirdTexture(skin: PlayerState["skin"]) {
+    switch (skin) {
+      case "blue":
+        return "bluebird-midflap";
+      case "red":
+        return "redbird-midflap";
+      default:
+        return "yellowbird-midflap";
+    }
+  }
+
+  private getBirdAnimation(skin: PlayerState["skin"]) {
+    switch (skin) {
+      case "blue":
+        return "blue_fly";
+      case "red":
+        return "red_fly";
+      default:
+        return "yellow_fly";
+    }
+  }
+
+  private addPipe(pipe: PipeState) {
+    const top = this.add.image(pipe.x, pipe.gapY - this.pipeGap / 2, "pipe");
+    top.setOrigin(0.5, 1);
+    top.setFlipY(true);
+    top.setDepth(3);
+
+    const bottom = this.add.image(pipe.x, pipe.gapY + this.pipeGap / 2, "pipe");
+    bottom.setOrigin(0.5, 0);
+    bottom.setDepth(3);
+
+    this.pipeSprites.set(pipe.id, { top, bottom });
+    this.updatePipe(pipe);
+  }
+
+  private updatePipe(pipe: PipeState) {
+    const sprites = this.pipeSprites.get(pipe.id);
+    if (!sprites) {
+      return;
+    }
+
+    sprites.top.x = pipe.x;
+    sprites.bottom.x = pipe.x;
+    sprites.top.y = pipe.gapY - this.pipeGap / 2;
+    sprites.bottom.y = pipe.gapY + this.pipeGap / 2;
+  }
+
+  private removePipe(id: number) {
+    const sprites = this.pipeSprites.get(id);
+    if (!sprites) {
+      return;
+    }
+
+    sprites.top.destroy();
+    sprites.bottom.destroy();
+    this.pipeSprites.delete(id);
+  }
+
+  private refreshScoreboard() {
+    if (!this.room) {
+      return;
+    }
+
+    const running = this.room.state.running as boolean;
+    const players: Array<{ name: string; score: number; alive: boolean; ready: boolean; isLocal: boolean }> = [];
+
+    this.room.state.players.forEach((player: PlayerState, sessionId: string) => {
+      players.push({
+        name: player.name,
+        score: player.score,
+        alive: player.alive,
+        ready: player.ready,
+        isLocal: sessionId === this.localPlayerId,
+      });
+    });
+
+    players.sort((a, b) => {
+      if (b.score === a.score) {
+        return a.name.localeCompare(b.name);
+      }
+      return b.score - a.score;
+    });
+
+    if (players.length === 0) {
+      this.scoreText.setText("Waiting for players...");
+    } else {
+      const lines = players.map((player) => {
+        const prefix = player.isLocal ? "▶ " : "";
+        const status = running
+          ? player.alive
+            ? "🟢"
+            : "✖"
+          : player.ready
+          ? "✅"
+          : "⏳";
+        return `${prefix}${player.name}: ${player.score} ${status}`;
+      });
+      this.scoreText.setText(lines.join("\n"));
+    }
+
+    this.scoreBackdrop.width = this.scoreText.width + 40;
+    this.scoreBackdrop.height = this.scoreText.height + 30;
+
+    this.refreshReadyInfo();
+  }
+
+  private updateStatusMessage() {
+    if (!this.room) {
+      return;
+    }
+
+    const running = this.room.state.running;
+    const winnerId = this.room.state.winnerId as string;
+
+    if (!running) {
+      const playerCount = this.getPlayerCount();
+      const readyCount = this.getReadyCount();
+      if (winnerId) {
+        const winner = this.room.state.players.get(winnerId) as PlayerState | undefined;
+        const winnerName = winner ? winner.name : "Nobody";
+        this.statusText.setText(
+          `${winnerName} wins!\nClick Ready Up when you're ready for the next round.`,
+        );
+      } else if (playerCount > 0) {
+        this.statusText.setText(
+          `Click Ready Up when you're set to fly!\nReady: ${readyCount}/${playerCount}`,
+        );
+      } else {
+        this.statusText.setText("Waiting for players to join...");
+      }
+    } else {
+      this.statusText.setText("Flap to stay alive! Last bird standing wins.");
+    }
+
+    this.refreshReadyInfo();
+  }
+
+  private getPlayerCount() {
+    if (!this.room) {
+      return 0;
+    }
+
+    let count = 0;
+    this.room.state.players.forEach(() => {
+      count += 1;
+    });
+    return count;
+  }
+
+  private getReadyCount() {
+    if (!this.room) {
+      return 0;
+    }
+
+    let count = 0;
+    this.room.state.players.forEach((player: PlayerState) => {
+      if (player.ready) {
+        count += 1;
+      }
+    });
+    return count;
+  }
+
+  private updateReadyUI() {
+    if (!this.readyButton || !this.readyButtonBg || !this.readyButtonText || !this.readyInfoText) {
+      return;
+    }
+
+    const hasRoom = !!this.room;
+    const running = hasRoom ? (this.room?.state.running as boolean) : false;
+    const shouldShow = hasRoom && !running;
+
+    this.readyButton.setVisible(shouldShow);
+    this.readyInfoText.setVisible(shouldShow);
+
+    if (!shouldShow) {
+      return;
+    }
+
+    const fillColor = this.localReady ? 0x2ecc71 : 0xe67e22;
+    const fillAlpha = this.localReady ? 0.95 : 0.9;
+    this.readyButtonBg.setFillStyle(fillColor, fillAlpha);
+    this.readyButtonText.setText(this.localReady ? "Cancel Ready" : "Ready Up");
+  }
+
+  private refreshReadyInfo() {
+    if (!this.readyInfoText) {
+      return;
+    }
+
+    const ready = this.getReadyCount();
+    const total = this.getPlayerCount();
+    this.readyInfoText.setText(`Ready: ${ready}/${total}`);
   }
 }

--- a/packages/client/src/scenes/MainMenu.ts
+++ b/packages/client/src/scenes/MainMenu.ts
@@ -7,18 +7,21 @@ export class MainMenu extends Scene {
   }
 
   create() {
-    const bg = this.add.image(this.cameras.main.width / 2, this.cameras.main.height / 2, "background");
-    let scaleX = this.cameras.main.width / bg.width + 0.2;
-    let scaleY = this.cameras.main.height / bg.height + 0.2;
-    let scale = Math.max(scaleX, scaleY);
-    bg.setScale(scale).setScrollFactor(0);
+    const { width, height } = this.cameras.main;
 
-    this.add.image(Number(this.game.config.width) * 0.5, 300, "logo");
+    const bg = this.add
+      .tileSprite(0, 0, width * 1.5, height, "background-day")
+      .setOrigin(0, 0);
+    this.add.tileSprite(0, height - 112, width * 1.5, 112, "base").setOrigin(0, 0);
 
     this.add
-      .text(Number(this.game.config.width) * 0.5, 460, "Main Menu", {
+      .image(Number(this.game.config.width) * 0.5, Number(this.game.config.height) * 0.35, "message")
+      .setScale(1.2);
+
+    this.add
+      .text(Number(this.game.config.width) * 0.5, Number(this.game.config.height) * 0.65, "Tap or press SPACE to join", {
         fontFamily: "Arial Black",
-        fontSize: 38,
+        fontSize: 32,
         color: "#ffffff",
         stroke: "#000000",
         strokeThickness: 8,
@@ -27,6 +30,11 @@ export class MainMenu extends Scene {
       .setOrigin(0.5);
 
     this.input.once("pointerdown", async () => {
+      await authorizeDiscordUser();
+      this.scene.start("Game");
+    });
+
+    this.input.keyboard?.once("keydown-SPACE", async () => {
       await authorizeDiscordUser();
       this.scene.start("Game");
     });

--- a/packages/client/src/scenes/Preloader.ts
+++ b/packages/client/src/scenes/Preloader.ts
@@ -6,14 +6,13 @@ export class Preloader extends Scene {
   }
 
   init() {
-    const bg = this.add.image(
-      this.cameras.main.width / 2,
-      this.cameras.main.height / 2,
-      "background"
+    const bg = this.add
+      .image(this.cameras.main.width / 2, this.cameras.main.height / 2, "background-day")
+      .setOrigin(0.5, 0.5);
+    const scale = Math.max(
+      this.cameras.main.width / bg.width,
+      this.cameras.main.height / bg.height
     );
-    let scaleX = this.cameras.main.width / bg.width + 0.2;
-    let scaleY = this.cameras.main.height / bg.height + 0.2;
-    let scale = Math.max(scaleX, scaleY);
     bg.setScale(scale).setScrollFactor(0);
 
     //  A simple progress bar. This is the outline of the bar.
@@ -44,32 +43,77 @@ export class Preloader extends Scene {
 
   preload() {
     //  Load the assets for the game - Replace with your own assets
-    this.load.setPath("/.proxy/assets");
+    this.load.setPath("/.proxy/assets/flappy-bird-assets/sprites");
 
-    // Load the alphabet images
-    const alphabetArray = "abcd".split(""); // efghijklmnopqrstuvwxyz
+    this.load.image("background-day", "background-day.png");
+    this.load.image("background-night", "background-night.png");
+    this.load.image("pipe", "pipe-green.png");
+    this.load.image("base", "base.png");
+    this.load.image("message", "message.png");
+    this.load.image("gameover", "gameover.png");
+    this.load.image("score-0", "0.png");
+    this.load.image("score-1", "1.png");
+    this.load.image("score-2", "2.png");
+    this.load.image("score-3", "3.png");
+    this.load.image("score-4", "4.png");
+    this.load.image("score-5", "5.png");
+    this.load.image("score-6", "6.png");
+    this.load.image("score-7", "7.png");
+    this.load.image("score-8", "8.png");
+    this.load.image("score-9", "9.png");
 
-    alphabetArray.forEach((letter) => {
-      this.load.image(letter, `${letter}.png`);
-    });
+    this.load.image("yellowbird-downflap", "yellowbird-downflap.png");
+    this.load.image("yellowbird-midflap", "yellowbird-midflap.png");
+    this.load.image("yellowbird-upflap", "yellowbird-upflap.png");
+    this.load.image("bluebird-downflap", "bluebird-downflap.png");
+    this.load.image("bluebird-midflap", "bluebird-midflap.png");
+    this.load.image("bluebird-upflap", "bluebird-upflap.png");
+    this.load.image("redbird-downflap", "redbird-downflap.png");
+    this.load.image("redbird-midflap", "redbird-midflap.png");
+    this.load.image("redbird-upflap", "redbird-upflap.png");
 
-    this.load.image("smile", "smile.png");
-    this.load.image("alien", "alien.png");
-    this.load.image("logo", "logo.png");
-    this.load.image("nought_1", "nought.png");
-    this.load.image("nought_2", "nought.png");
-    this.load.image("nought_3", "nought.png");
-    this.load.image("cross_1", "cross.png");
-    this.load.image("cross_2", "cross.png");
-    this.load.image("cross_3", "cross.png");
-    this.load.image("grid", "grid.png");
+    this.load.setPath("/.proxy/assets/flappy-bird-assets/audio");
+    this.load.audio("wing", ["wing.ogg", "wing.wav"]);
+    this.load.audio("point", ["point.ogg", "point.wav"]);
+    this.load.audio("hit", ["hit.ogg", "hit.wav"]);
+    this.load.audio("die", ["die.ogg", "die.wav"]);
+    this.load.audio("swoosh", ["swoosh.ogg", "swoosh.wav"]);
   }
 
   create() {
-    //  When all the assets have loaded, it's often worth creating global objects here that the rest of the game can use.
-    //  For example, you can define global animations here, so we can use them in other scenes.
+    this.anims.create({
+      key: "yellow_fly",
+      frames: [
+        { key: "yellowbird-downflap" },
+        { key: "yellowbird-midflap" },
+        { key: "yellowbird-upflap" },
+      ],
+      frameRate: 12,
+      repeat: -1,
+    });
 
-    //  Move to the MainMenu. You could also swap this for a Scene Transition, such as a camera fade.
+    this.anims.create({
+      key: "blue_fly",
+      frames: [
+        { key: "bluebird-downflap" },
+        { key: "bluebird-midflap" },
+        { key: "bluebird-upflap" },
+      ],
+      frameRate: 12,
+      repeat: -1,
+    });
+
+    this.anims.create({
+      key: "red_fly",
+      frames: [
+        { key: "redbird-downflap" },
+        { key: "redbird-midflap" },
+        { key: "redbird-upflap" },
+      ],
+      frameRate: 12,
+      repeat: -1,
+    });
+
     this.scene.start("MainMenu");
   }
 }

--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -1,59 +1,242 @@
 import { Client, Room } from "colyseus";
-import { GameState, Draggables } from "../schemas/GameState";
+import { GameState, PlayerState, PipeState } from "../schemas/GameState";
 
 export class GameRoom extends Room<GameState> {
   state = new GameState();
   maxClients = 25; // Current Discord limit is 25
 
-  onCreate(options: any): void | Promise<any> {
-    const draggableList = [
-      "smile",
-      "alien",
-      "a",
-      "b",
-      "c",
-      "d",
-      "cross_1",
-      "cross_2",
-      "cross_3",
-      "nought_1",
-      "nought_2",
-      "nought_3",
-    ];
-    draggableList.forEach((draggable, index) => {
-      const draggableObject = new Draggables();
+  private gravity = 1600;
+  private flapVelocity = -550;
+  private pipeSpeed = 220;
+  private pipeInterval = 1800;
+  private pipeGap = 230;
+  private floorHeight = 112;
+  private birdX = 260;
+  private birdHalfWidth = 17;
+  private birdHalfHeight = 12;
+  private pipeWidth = 52;
+  private nextPipeId = 1;
+  private elapsedSincePipe = 0;
+  private skins: Array<PlayerState["skin"]> = ["yellow", "blue", "red"];
 
-      const offset = 500;
-      const minWidth = offset;
-      const maxWidth = options.screenWidth / 2 + 250;
-      const minHeight = offset;
-      const maxHeight = options.screenHeight / 2;
+  private worldWidth = 1280;
+  private worldHeight = 720;
 
-      draggableObject.x =
-        Math.floor(Math.random() * (maxWidth - minWidth + 1)) + minWidth;
-      draggableObject.y =
-        Math.floor(Math.random() * (maxHeight - minHeight + 1)) + minHeight;
-      draggableObject.imageId = draggable;
+  onCreate(): void {
+    this.setSimulationInterval((deltaTime) => this.update(deltaTime / 1000));
 
-      this.state.draggables.set(draggable, draggableObject);
+    this.onMessage("flap", (client) => {
+      const player = this.state.players.get(client.sessionId);
+      if (!player) {
+        return;
+      }
+
+      if (player.alive) {
+        player.velocity = this.flapVelocity;
+      }
     });
 
-    this.onMessage("move", (client, message) => {
-      // Update image position based on data received
-      const image = this.state.draggables.get(message.imageId);
-      if (image) {
-        image.x = message.x;
-        image.y = message.y;
-        this.broadcast("move", this.state.draggables);
+    this.onMessage("setReady", (client, message: { ready: boolean }) => {
+      const player = this.state.players.get(client.sessionId);
+      if (!player || this.state.running) {
+        return;
+      }
+
+      player.ready = !!message?.ready;
+
+      if (this.areAllPlayersReady()) {
+        this.startRound();
       }
     });
   }
 
-  onJoin(client: Client, options?: any, auth?: any): void | Promise<any> {
+  onJoin(client: Client, options?: any): void {
     console.log(`Client joined: ${client.sessionId}`);
+
+    const player = new PlayerState();
+    player.name = options?.name || `Bird ${client.sessionId.slice(0, 4)}`;
+    player.skin = this.assignSkin();
+    player.ready = false;
+    player.y = this.worldHeight / 2;
+    player.velocity = 0;
+    player.alive = true;
+    player.score = 0;
+    player.lastPassedPipeId = 0;
+
+    this.state.players.set(client.sessionId, player);
   }
 
-  onLeave(client: Client, consented: boolean): void | Promise<any> {
+  onLeave(client: Client): void {
     console.log(`Client left: ${client.sessionId}`);
+    this.state.players.delete(client.sessionId);
+
+    if (this.state.players.size === 0) {
+      this.resetRound();
+    }
+  }
+
+  private assignSkin(): PlayerState["skin"] {
+    const activeSkins = new Map<PlayerState["skin"], number>();
+    for (const [, player] of this.state.players) {
+      activeSkins.set(player.skin, (activeSkins.get(player.skin) || 0) + 1);
+    }
+
+    let selected: PlayerState["skin"] = this.skins[0];
+    let minCount = Number.MAX_SAFE_INTEGER;
+    this.skins.forEach((skin) => {
+      const count = activeSkins.get(skin) || 0;
+      if (count < minCount) {
+        minCount = count;
+        selected = skin;
+      }
+    });
+
+    return selected;
+  }
+
+  private resetRound() {
+    this.state.running = false;
+    this.state.winnerId = "";
+    this.elapsedSincePipe = 0;
+    this.nextPipeId = 1;
+    this.state.pipes.splice(0, this.state.pipes.length);
+
+    for (const [, player] of this.state.players) {
+      player.ready = false;
+    }
+  }
+
+  private startRound() {
+    this.resetRound();
+    this.state.running = true;
+
+    for (const [, player] of this.state.players) {
+      player.alive = true;
+      player.y = this.worldHeight / 2;
+      player.velocity = 0;
+      player.score = 0;
+      player.lastPassedPipeId = 0;
+    }
+
+    const initialSpacing = 280;
+    for (let i = 0; i < 3; i += 1) {
+      this.spawnPipePair(this.worldWidth + 200 + i * initialSpacing);
+    }
+  }
+
+  private spawnPipePair(startX?: number) {
+    const pipe = new PipeState();
+    pipe.id = this.nextPipeId++;
+    pipe.x = startX ?? this.worldWidth + 200;
+
+    const minY = 180;
+    const maxY = this.worldHeight - this.floorHeight - 180;
+    pipe.gapY = minY + Math.random() * Math.max(0, maxY - minY);
+
+    this.state.pipes.push(pipe);
+  }
+
+  private update(delta: number) {
+    if (!this.state.running) {
+      return;
+    }
+
+    this.elapsedSincePipe += delta * 1000;
+    if (this.elapsedSincePipe >= this.pipeInterval) {
+      this.elapsedSincePipe = 0;
+      this.spawnPipePair();
+    }
+
+    const floorY = this.worldHeight - this.floorHeight;
+
+    for (const [, player] of this.state.players) {
+      if (!player.alive) {
+        continue;
+      }
+
+      player.velocity += this.gravity * delta;
+      player.y += player.velocity * delta;
+
+      if (player.y < this.birdHalfHeight) {
+        player.y = this.birdHalfHeight;
+      }
+
+      if (player.y + this.birdHalfHeight >= floorY) {
+        player.y = floorY - this.birdHalfHeight;
+        player.alive = false;
+        continue;
+      }
+
+      for (const pipe of this.state.pipes) {
+        const pipeLeft = pipe.x - this.pipeWidth / 2;
+        const pipeRight = pipe.x + this.pipeWidth / 2;
+        const gapTop = pipe.gapY - this.pipeGap / 2;
+        const gapBottom = pipe.gapY + this.pipeGap / 2;
+
+        const birdLeft = this.birdX - this.birdHalfWidth;
+        const birdRight = this.birdX + this.birdHalfWidth;
+        const birdTop = player.y - this.birdHalfHeight;
+        const birdBottom = player.y + this.birdHalfHeight;
+
+        if (birdRight > pipeLeft && birdLeft < pipeRight) {
+          if (birdTop < gapTop || birdBottom > gapBottom) {
+            player.alive = false;
+            break;
+          }
+        }
+
+        if (pipeRight < birdLeft && pipe.id > player.lastPassedPipeId) {
+          player.lastPassedPipeId = pipe.id;
+          player.score += 1;
+        }
+      }
+    }
+
+    for (const pipe of this.state.pipes) {
+      pipe.x -= this.pipeSpeed * delta;
+    }
+
+    while (this.state.pipes.length > 0 && this.state.pipes[0].x < -this.pipeWidth) {
+      this.state.pipes.shift();
+    }
+
+    const alivePlayers = Array.from(this.state.players.values()).filter((player) => player.alive);
+    if (alivePlayers.length <= 1) {
+      this.state.running = false;
+      this.state.winnerId = alivePlayers.length === 1 ? this.findPlayerId(alivePlayers[0]) : "";
+      this.state.pipes.splice(0, this.state.pipes.length);
+
+      for (const [, player] of this.state.players) {
+        player.ready = false;
+      }
+    }
+  }
+
+  private areAllPlayersReady() {
+    if (this.state.players.size === 0) {
+      return false;
+    }
+
+    for (const [, player] of this.state.players) {
+      if (!player.ready) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private findPlayerId(target: PlayerState | null): string {
+    if (!target) {
+      return "";
+    }
+
+    for (const [sessionId, player] of this.state.players) {
+      if (player === target) {
+        return sessionId;
+      }
+    }
+
+    return "";
   }
 }

--- a/packages/server/src/schemas/GameState.ts
+++ b/packages/server/src/schemas/GameState.ts
@@ -1,17 +1,52 @@
-import { Schema, type, MapSchema } from "@colyseus/schema";
+import { Schema, type, MapSchema, ArraySchema } from "@colyseus/schema";
 
-export class Draggables extends Schema {
+export class PlayerState extends Schema {
   @type("string")
-  imageId = "";
+  name = "";
+
+  @type("string")
+  skin: "yellow" | "blue" | "red" = "yellow";
+
+  @type("boolean")
+  ready = false;
+
+  @type("number")
+  y = 0;
+
+  @type("number")
+  velocity = 0;
+
+  @type("boolean")
+  alive = true;
+
+  @type("number")
+  score = 0;
+
+  @type("number")
+  lastPassedPipeId = 0;
+}
+
+export class PipeState extends Schema {
+  @type("number")
+  id = 0;
 
   @type("number")
   x = 0;
 
   @type("number")
-  y = 0;
+  gapY = 0;
 }
 
 export class GameState extends Schema {
-  @type({ map: Draggables })
-  draggables = new MapSchema<Draggables>();
+  @type({ map: PlayerState })
+  players = new MapSchema<PlayerState>();
+
+  @type([PipeState])
+  pipes = new ArraySchema<PipeState>();
+
+  @type("boolean")
+  running = false;
+
+  @type("string")
+  winnerId = "";
 }


### PR DESCRIPTION
## Summary
- require every connected player to ready up before starting a round and reset ready flags whenever a match ends
- expose a ready button, player counts, and ready indicators in the client lobby while blocking flaps until gameplay begins
- ensure existing players and pipes are bound immediately on join so ready counts reflect the current lobby state

## Testing
- npm run client-build
- (cd packages/server && npm run build)

------
https://chatgpt.com/codex/tasks/task_e_68dabd92b638832681cbc61e7b206da2