### PR TITLE
Fix replication sync for gameplay state

### DIFF
--- a/packages/client/src/scenes/Game.ts
+++ b/packages/client/src/scenes/Game.ts
@@ -1,31 +1,27 @@
 import { Scene } from "phaser";
 import { Room, Client, getStateCallbacks } from "colyseus.js";
 import { discordSdk, getUserName } from "../utils/discordSDK";
-
-type PlayerState = {
-  name: string;
-  skin: "yellow" | "blue" | "red";
-  y: number;
-  velocity: number;
-  alive: boolean;
-  score: number;
-  lastPassedPipeId: number;
-  ready: boolean;
-};
-
-type PipeState = {
-  id: number;
-  x: number;
-  gapY: number;
-};
+import type {
+  ReplicatedChange,
+  ReplicatedPipeState,
+  ReplicatedPlayerState,
+  ReplicatedRoomState,
+} from "../types/replication";
 
 export class Game extends Scene {
-  private room?: Room<any>;
+  // --- Networking & replication -------------------------------------------------
+  private room?: Room<ReplicatedRoomState>;
+  private localPlayerId = "";
+  private localPlayerReady = false;
+  private lastKnownRunning = false;
+
+  private readonly playerSprites = new Map<string, Phaser.GameObjects.Sprite>();
+  private readonly playerCache = new Map<string, { alive: boolean; score: number; ready: boolean }>();
+  private readonly pipeSprites = new Map<number, { top: Phaser.GameObjects.Image; bottom: Phaser.GameObjects.Image }>();
+
+  // --- Scene references --------------------------------------------------------
   private background!: Phaser.GameObjects.TileSprite;
   private ground!: Phaser.GameObjects.TileSprite;
-  private playerSprites = new Map<string, Phaser.GameObjects.Sprite>();
-  private pipeSprites = new Map<number, { top: Phaser.GameObjects.Image; bottom: Phaser.GameObjects.Image }>();
-  private playerCache = new Map<string, { alive: boolean; score: number; ready: boolean }>();
   private scoreText!: Phaser.GameObjects.Text;
   private scoreBackdrop!: Phaser.GameObjects.Rectangle;
   private statusText!: Phaser.GameObjects.Text;
@@ -36,9 +32,8 @@ export class Game extends Scene {
   private gameOverText?: Phaser.GameObjects.Text;
   private restartButton?: Phaser.GameObjects.Rectangle;
   private restartButtonLabel?: Phaser.GameObjects.Text;
-  private localPlayerId = "";
-  private localPlayerReady = false;
-  private lastKnownRunning = false;
+
+  // --- Simulation tuning -------------------------------------------------------
   private readonly pipeGap = 230;
   private readonly birdX = 260;
   private readonly scrollSpeed = 220;
@@ -78,57 +73,6 @@ export class Game extends Scene {
     const scroll = (this.scrollSpeed * delta) / 1000;
     this.background.tilePositionX += scroll;
     this.ground.tilePositionX += scroll;
-    
-    // Periodic sync for ready state changes and running state
-    if (this.room && this.room.state && this.room.state.players) {
-      let needsUIUpdate = false;
-      
-      // Check if running state changed
-      const currentRunning = this.room.state.running as boolean;
-      if (currentRunning !== this.lastKnownRunning) {
-        console.log("Running state changed from", this.lastKnownRunning, "to", currentRunning);
-        this.lastKnownRunning = currentRunning;
-        needsUIUpdate = true;
-        this.updateStatusMessage();
-        
-        // When game starts, check for existing pipes
-        if (currentRunning && this.room.state.pipes) {
-          console.log("Game started, checking for pipes:", this.room.state.pipes.length);
-          this.room.state.pipes.forEach((pipe: PipeState) => {
-            console.log("Pipe in room state:", pipe.id, "at x:", pipe.x, "gapY:", pipe.gapY);
-            if (!this.pipeSprites.has(pipe.id)) {
-              console.log("Adding missing pipe:", pipe.id);
-              this.addPipe(pipe);
-            } else {
-              console.log("Pipe already exists:", pipe.id);
-            }
-          });
-        }
-      }
-      
-      this.room.state.players.forEach((player: PlayerState, sessionId: string) => {
-        const cached = this.playerCache.get(sessionId);
-        if (cached && cached.ready !== player.ready) {
-          console.log("Ready state changed for player:", sessionId, "from", cached.ready, "to", player.ready);
-          this.syncPlayer(sessionId, player, []);
-          needsUIUpdate = true;
-        } else if (!cached) {
-          // If player is not in cache, add them
-          console.log("Player not in cache, adding:", sessionId);
-          this.addPlayer(sessionId, player);
-          needsUIUpdate = true;
-        }
-        // Debug: log current ready state
-        if (sessionId === this.localPlayerId) {
-          console.log("Local player ready state - cached:", cached?.ready, "room:", player.ready);
-        }
-      });
-      
-      // Force UI update if any state changed
-      if (needsUIUpdate) {
-        this.updateReadyUI();
-      }
-    }
   }
 
   private setupWorld() {
@@ -377,13 +321,6 @@ export class Game extends Scene {
     // Send to server
     this.room.send("setReady", { ready: nextReady });
     console.log("Sent setReady message to server");
-    
-    // Also update the server state immediately to avoid sync issues
-    const player = this.room.state.players.get(this.localPlayerId);
-    if (player) {
-      player.ready = nextReady;
-      console.log("Updated server state immediately for player:", this.localPlayerId, "to:", nextReady);
-    }
   }
 
   private updateReadyButtonStyle() {
@@ -460,7 +397,7 @@ export class Game extends Scene {
     const client = new Client(`${url}`);
 
     try {
-      this.room = await client.joinOrCreate("game", {
+      this.room = await client.joinOrCreate<ReplicatedRoomState>("game", {
         name: getUserName(),
       });
       this.localPlayerId = this.room.sessionId;
@@ -479,67 +416,97 @@ export class Game extends Scene {
 
     const $ = getStateCallbacks(this.room);
 
-    // Handle existing players (in case they were added before listeners were registered)
-    if (this.room.state.players) {
-      console.log("Found", this.room.state.players.size, "existing players in room");
-      this.room.state.players.forEach((player: PlayerState, sessionId: string) => {
-        console.log("Existing player in room:", sessionId, player.name, "ready:", player.ready);
-        this.addPlayer(sessionId, player);
-        
-        // Note: Individual player onChange callbacks are not working properly
-        // We'll use periodic sync instead
-      });
-    }
-
-    // Handle existing pipes (in case they were added before listeners were registered)
-    if (this.room.state.pipes) {
-      console.log("Found", this.room.state.pipes.length, "existing pipes in room");
-      this.room.state.pipes.forEach((pipe: PipeState) => {
-        console.log("Existing pipe in room:", pipe.id, "at x:", pipe.x, "gapY:", pipe.gapY);
-        this.addPipe(pipe);
-      });
-    }
-
-    $(this.room.state.players).onAdd((player: PlayerState, sessionId: string) => {
-      console.log("Player added to room via onAdd:", sessionId, player.name, "ready:", player.ready);
+    const bindPlayer = (sessionId: string, player: ReplicatedPlayerState) => {
+      console.log("Binding player state for", sessionId, player.name);
       this.addPlayer(sessionId, player);
-      
-      // Note: Individual player onChange callbacks are not working properly
-      // We'll use periodic sync instead
+      $(player).onChange((changes: ReplicatedChange[]) => this.syncPlayer(sessionId, player, changes));
+    };
+
+    const bindPipe = (pipe: ReplicatedPipeState) => {
+      console.log("Binding pipe state", pipe.id, "at", pipe.x);
+      this.addPipe(pipe);
+      $(pipe).onChange(() => this.updatePipe(pipe));
+    };
+
+    this.room.state.players?.forEach((player: ReplicatedPlayerState, sessionId: string) => {
+      bindPlayer(sessionId, player);
     });
 
-    $(this.room.state.players).onRemove((_player: PlayerState, sessionId: string) => {
+    $(this.room.state.players).onAdd((player: ReplicatedPlayerState, sessionId: string) => {
+      bindPlayer(sessionId, player);
+    });
+
+    $(this.room.state.players).onRemove((_player: ReplicatedPlayerState, sessionId: string) => {
       this.removePlayer(sessionId);
     });
 
-    $(this.room.state.pipes).onAdd((pipe: PipeState) => {
-      console.log("Pipe added to room state:", pipe);
-      this.addPipe(pipe);
+    this.room.state.pipes?.forEach((pipe: ReplicatedPipeState) => {
+      bindPipe(pipe);
     });
 
-    $(this.room.state.pipes).onRemove((pipe: PipeState) => {
+    $(this.room.state.pipes).onAdd((pipe: ReplicatedPipeState) => {
+      bindPipe(pipe);
+    });
+
+    $(this.room.state.pipes).onRemove((pipe: ReplicatedPipeState) => {
       this.removePipe(pipe.id);
     });
 
-    $(this.room.state).onChange((changes: any[]) => {
-      console.log("Room state changed:", changes);
-      if (changes && Array.isArray(changes)) {
-        changes.forEach((change) => {
-          console.log("State change field:", change.field, "value:", change.value);
-          if (change.field === "running" || change.field === "winnerId") {
-            console.log("Updating status message due to running/winnerId change");
-            this.updateStatusMessage();
-          }
-        });
-      } else {
-        console.log("State change callback received non-array data:", changes);
-      }
-    });
+    $(this.room.state).onChange((changes: ReplicatedChange[]) => this.handleRoomStateChange(changes));
 
     this.updateStatusMessage();
   }
 
-  private addPlayer(sessionId: string, player: PlayerState) {
+  private handleRoomStateChange(changes: ReplicatedChange[]) {
+    if (!Array.isArray(changes)) {
+      return;
+    }
+
+    let runningChanged = false;
+    let winnerChanged = false;
+
+    changes.forEach((change) => {
+      if (change.field === "running") {
+        runningChanged = true;
+      } else if (change.field === "winnerId") {
+        winnerChanged = true;
+      }
+    });
+
+    if (runningChanged) {
+      const currentRunning = Boolean(this.room?.state.running);
+      if (currentRunning !== this.lastKnownRunning) {
+        this.lastKnownRunning = currentRunning;
+        this.onRunningStateChanged(currentRunning);
+      }
+    }
+
+    if (winnerChanged) {
+      this.updateStatusMessage();
+    }
+  }
+
+  private onRunningStateChanged(running: boolean) {
+    console.log("Running state changed:", running);
+
+    if (running) {
+      this.gameOverScreen?.setVisible(false);
+      if (this.room?.state.pipes) {
+        this.room.state.pipes.forEach((pipe: ReplicatedPipeState) => {
+          if (!this.pipeSprites.has(pipe.id)) {
+            this.addPipe(pipe);
+          } else {
+            this.updatePipe(pipe);
+          }
+        });
+      }
+    }
+
+    this.refreshScoreboard();
+    this.updateStatusMessage();
+  }
+
+  private addPlayer(sessionId: string, player: ReplicatedPlayerState) {
     console.log("Adding player:", sessionId, "with ready state:", player.ready);
     
     const sprite = this.add.sprite(this.birdX, player.y, this.getBirdTexture(player.skin));
@@ -582,7 +549,11 @@ export class Game extends Scene {
     this.updateReadyUI();
   }
 
-  private syncPlayer(sessionId: string, player: PlayerState, changes: any[]) {
+  private syncPlayer(
+    sessionId: string,
+    player: ReplicatedPlayerState,
+    changes: ReplicatedChange[] | undefined,
+  ) {
     const sprite = this.playerSprites.get(sessionId);
     if (!sprite) {
       return;
@@ -623,7 +594,7 @@ export class Game extends Scene {
 
     const changeList = Array.isArray(changes) ? changes : [];
     const shouldRefresh = changeList.some(
-      (change: any) => change.field === "score" || change.field === "alive" || change.field === "ready",
+      (change) => change.field === "score" || change.field === "alive" || change.field === "ready",
     );
     if (shouldRefresh) {
       this.refreshScoreboard();
@@ -635,7 +606,7 @@ export class Game extends Scene {
     }
   }
 
-  private getBirdTexture(skin: PlayerState["skin"]) {
+  private getBirdTexture(skin: ReplicatedPlayerState["skin"]) {
     switch (skin) {
       case "blue":
         return "bluebird-midflap";
@@ -646,7 +617,7 @@ export class Game extends Scene {
     }
   }
 
-  private getBirdAnimation(skin: PlayerState["skin"]) {
+  private getBirdAnimation(skin: ReplicatedPlayerState["skin"]) {
     switch (skin) {
       case "blue":
         return "blue_fly";
@@ -657,7 +628,7 @@ export class Game extends Scene {
     }
   }
 
-  private addPipe(pipe: PipeState) {
+  private addPipe(pipe: ReplicatedPipeState) {
     console.log("Adding pipe:", pipe.id, "at x:", pipe.x, "gapY:", pipe.gapY);
     
     // Check if pipe texture exists
@@ -705,7 +676,7 @@ export class Game extends Scene {
     console.log("Pipe added successfully, total pipes:", this.pipeSprites.size);
   }
 
-  private updatePipe(pipe: PipeState) {
+  private updatePipe(pipe: ReplicatedPipeState) {
     const sprites = this.pipeSprites.get(pipe.id);
     if (!sprites) {
       return;
@@ -735,7 +706,7 @@ export class Game extends Scene {
 
     const players: Array<{ name: string; score: number; alive: boolean; ready: boolean; isLocal: boolean }> = [];
 
-    this.room.state.players.forEach((player: PlayerState, sessionId: string) => {
+    this.room.state.players.forEach((player: ReplicatedPlayerState, sessionId: string) => {
       players.push({
         name: player.name,
         score: player.score,
@@ -799,7 +770,7 @@ export class Game extends Scene {
       }
       
       if (winnerId) {
-        const winner = this.room.state.players.get(winnerId) as PlayerState | undefined;
+        const winner = this.room.state.players.get(winnerId) as ReplicatedPlayerState | undefined;
         const winnerName = winner ? winner.name : "Nobody";
         const isLocalWinner = winnerId === this.localPlayerId;
         this.statusText.setText(`${winnerName} wins!\nPress Ready to play again.`);
@@ -847,7 +818,7 @@ export class Game extends Scene {
     }
 
     let count = 0;
-    this.room.state.players.forEach((player: PlayerState, sessionId: string) => {
+    this.room.state.players.forEach((player: ReplicatedPlayerState, sessionId: string) => {
       if (player.ready) {
         count += 1;
         console.log("Player", sessionId, "is ready");

--- a/packages/client/src/types/replication.ts
+++ b/packages/client/src/types/replication.ts
@@ -1,0 +1,49 @@
+export type ReplicatedPlayerState = {
+  /** Player display name shown on the scoreboard. */
+  name: string;
+  /** Cosmetic skin identifier (mirrors the Colyseus schema). */
+  skin: "yellow" | "blue" | "red";
+  /** Vertical position within the world (authoritative on the server). */
+  y: number;
+  /** Current vertical velocity applied by the simulation. */
+  velocity: number;
+  /** Whether the player is still alive in the current round. */
+  alive: boolean;
+  /** Score accumulated by passing pipes. */
+  score: number;
+  /** Identifier of the most recent pipe successfully cleared. */
+  lastPassedPipeId: number;
+  /** Lobby ready state toggled by each player. */
+  ready: boolean;
+};
+
+export type ReplicatedPipeState = {
+  /** Unique identifier assigned by the server when spawning the pipe pair. */
+  id: number;
+  /** Horizontal position used for sprite placement and collision. */
+  x: number;
+  /** Vertical centre of the pipe gap. */
+  gapY: number;
+};
+
+export type ReplicatedRoomState = {
+  /** Map keyed by Colyseus session id with the authoritative player state. */
+  players: Map<string, ReplicatedPlayerState> & {
+    forEach: (callback: (player: ReplicatedPlayerState, sessionId: string) => void) => void;
+    get: (sessionId: string) => ReplicatedPlayerState | undefined;
+    delete: (sessionId: string) => boolean;
+    size: number;
+  };
+  /** Ordered list of pipes currently active in the world. */
+  pipes: Array<ReplicatedPipeState> & { length: number };
+  /** Whether the simulation is actively running. */
+  running: boolean;
+  /** Session id of the winning player when a multiplayer round ends. */
+  winnerId: string;
+};
+
+export type ReplicatedChange = {
+  field: string;
+  value?: unknown;
+  previousValue?: unknown;
+};

--- a/packages/server/src/rooms/GameRoom.ts
+++ b/packages/server/src/rooms/GameRoom.ts
@@ -3,25 +3,44 @@ import { GameState, PlayerState, PipeState } from "../schemas/GameState";
 import logger from "../logger";
 
 export class GameRoom extends Room<GameState> {
+  // Colyseus replicated state
   state = new GameState();
   maxClients = 25; // Current Discord limit is 25
 
-  private gravity = 400; // Reduced gravity for testing
-  private flapVelocity = -550;
-  private pipeSpeed = 220;
-  private pipeInterval = 1800;
-  private pipeGap = 230;
-  private floorHeight = 112;
-  private birdX = 260;
-  private birdHalfWidth = 17;
-  private birdHalfHeight = 12;
-  private pipeWidth = 52;
+  // Simulation configuration (not replicated)
+  private readonly physics = {
+    gravity: 400, // Reduced gravity for testing
+    flapVelocity: -550,
+  };
+
+  private readonly pipesConfig = {
+    speed: 220,
+    intervalMs: 1800,
+    gap: 230,
+    width: 52,
+  };
+
+  private readonly world = {
+    width: 1280,
+    height: 720,
+    floorHeight: 112,
+  };
+
+  private readonly bird = {
+    x: 260,
+    halfWidth: 17,
+    halfHeight: 12,
+  };
+
+  private readonly roundConfig = {
+    initialLaunchVelocity: -300,
+    initialPipeSpacing: 280,
+    initialPipeCount: 3,
+  };
+
   private nextPipeId = 1;
   private elapsedSincePipe = 0;
-  private skins: Array<PlayerState["skin"]> = ["yellow", "blue", "red"];
-
-  private worldWidth = 1280;
-  private worldHeight = 720;
+  private readonly availableSkins: Array<PlayerState["skin"]> = ["yellow", "blue", "red"];
 
   onCreate(): void {
     this.setSimulationInterval((deltaTime) => this.update(deltaTime / 1000));
@@ -36,7 +55,7 @@ export class GameRoom extends Room<GameState> {
         return;
       }
 
-      player.velocity = this.flapVelocity;
+      player.velocity = this.physics.flapVelocity;
     });
 
     this.onMessage("setReady", (client, message: { ready?: boolean }) => {
@@ -60,7 +79,7 @@ export class GameRoom extends Room<GameState> {
     const player = new PlayerState();
     player.name = options?.name || `Bird ${client.sessionId.slice(0, 4)}`;
     player.skin = this.assignSkin();
-    player.y = this.worldHeight / 2;
+    player.y = this.world.height / 2;
     player.velocity = 0;
     player.alive = true;
     player.score = 0;
@@ -92,9 +111,9 @@ export class GameRoom extends Room<GameState> {
       activeSkins.set(player.skin, (activeSkins.get(player.skin) || 0) + 1);
     }
 
-    let selected: PlayerState["skin"] = this.skins[0];
+    let selected: PlayerState["skin"] = this.availableSkins[0];
     let minCount = Number.MAX_SAFE_INTEGER;
-    this.skins.forEach((skin) => {
+    this.availableSkins.forEach((skin) => {
       const count = activeSkins.get(skin) || 0;
       if (count < minCount) {
         minCount = count;
@@ -140,16 +159,18 @@ export class GameRoom extends Room<GameState> {
 
     for (const [, player] of this.state.players) {
       player.alive = true;
-      player.y = this.worldHeight / 2;
-      player.velocity = -300; // Give initial upward velocity to prevent immediate death
+      player.y = this.world.height / 2;
+      player.velocity = this.roundConfig.initialLaunchVelocity; // Give initial upward velocity to prevent immediate death
       player.score = 0;
       player.lastPassedPipeId = 0;
-      logger.info(`Player initialized: y=${player.y}, velocity=${player.velocity}, alive=${player.alive}, worldHeight=${this.worldHeight}`);
+      logger.info(
+        `Player initialized: y=${player.y}, velocity=${player.velocity}, alive=${player.alive}, worldHeight=${this.world.height}`,
+      );
     }
 
-    const initialSpacing = 280;
-    for (let i = 0; i < 3; i += 1) {
-      this.spawnPipePair(this.worldWidth + 200 + i * initialSpacing);
+    for (let i = 0; i < this.roundConfig.initialPipeCount; i += 1) {
+      const offset = this.world.width + 200 + i * this.roundConfig.initialPipeSpacing;
+      this.spawnPipePair(offset);
     }
     logger.info("Round started successfully");
   }
@@ -157,10 +178,10 @@ export class GameRoom extends Room<GameState> {
   private spawnPipePair(startX?: number) {
     const pipe = new PipeState();
     pipe.id = this.nextPipeId++;
-    pipe.x = startX ?? this.worldWidth + 200;
+    pipe.x = startX ?? this.world.width + 200;
 
     const minY = 180;
-    const maxY = this.worldHeight - this.floorHeight - 180;
+    const maxY = this.world.height - this.world.floorHeight - 180;
     pipe.gapY = minY + Math.random() * Math.max(0, maxY - minY);
 
     this.state.pipes.push(pipe);
@@ -173,42 +194,42 @@ export class GameRoom extends Room<GameState> {
     }
 
     this.elapsedSincePipe += delta * 1000;
-    if (this.elapsedSincePipe >= this.pipeInterval) {
+    if (this.elapsedSincePipe >= this.pipesConfig.intervalMs) {
       this.elapsedSincePipe = 0;
       this.spawnPipePair();
     }
 
-    const floorY = this.worldHeight - this.floorHeight;
+    const floorY = this.world.height - this.world.floorHeight;
 
     for (const [, player] of this.state.players) {
       if (!player.alive) {
         continue;
       }
 
-      player.velocity += this.gravity * delta;
+      player.velocity += this.physics.gravity * delta;
       player.y += player.velocity * delta;
 
-      if (player.y < this.birdHalfHeight) {
-        player.y = this.birdHalfHeight;
+      if (player.y < this.bird.halfHeight) {
+        player.y = this.bird.halfHeight;
       }
 
-      if (player.y + this.birdHalfHeight >= floorY) {
+      if (player.y + this.bird.halfHeight >= floorY) {
         logger.warn(`Player hit floor at y=${player.y}, floorY=${floorY}`);
-        player.y = floorY - this.birdHalfHeight;
+        player.y = floorY - this.bird.halfHeight;
         player.alive = false;
         continue;
       }
 
       for (const pipe of this.state.pipes) {
-        const pipeLeft = pipe.x - this.pipeWidth / 2;
-        const pipeRight = pipe.x + this.pipeWidth / 2;
-        const gapTop = pipe.gapY - this.pipeGap / 2;
-        const gapBottom = pipe.gapY + this.pipeGap / 2;
+        const pipeLeft = pipe.x - this.pipesConfig.width / 2;
+        const pipeRight = pipe.x + this.pipesConfig.width / 2;
+        const gapTop = pipe.gapY - this.pipesConfig.gap / 2;
+        const gapBottom = pipe.gapY + this.pipesConfig.gap / 2;
 
-        const birdLeft = this.birdX - this.birdHalfWidth;
-        const birdRight = this.birdX + this.birdHalfWidth;
-        const birdTop = player.y - this.birdHalfHeight;
-        const birdBottom = player.y + this.birdHalfHeight;
+        const birdLeft = this.bird.x - this.bird.halfWidth;
+        const birdRight = this.bird.x + this.bird.halfWidth;
+        const birdTop = player.y - this.bird.halfHeight;
+        const birdBottom = player.y + this.bird.halfHeight;
 
         if (birdRight > pipeLeft && birdLeft < pipeRight) {
           if (birdTop < gapTop || birdBottom > gapBottom) {
@@ -226,10 +247,10 @@ export class GameRoom extends Room<GameState> {
     }
 
     for (const pipe of this.state.pipes) {
-      pipe.x -= this.pipeSpeed * delta;
+      pipe.x -= this.pipesConfig.speed * delta;
     }
 
-    while (this.state.pipes.length > 0 && this.state.pipes[0].x < -this.pipeWidth) {
+    while (this.state.pipes.length > 0 && this.state.pipes[0].x < -this.pipesConfig.width) {
       this.state.pipes.shift();
     }
 


### PR DESCRIPTION
## Summary
- add explicit replication type definitions on the client to document the server-synchronised fields
- listen to Colyseus change events so player motion and pipes update immediately when the round starts
- regroup the server simulation configuration to clarify what is replicated versus local tuning values

## Testing
- npm run build (server)
- npm run build (client)

------
https://chatgpt.com/codex/tasks/task_e_68df18125f50832682225a0df5d242b9